### PR TITLE
Fix tool-use instructions and image handling in the generate method

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Ballerina"]
 distribution = "2201.12.0"
-keywords = ["Agent", "Ollama", "Model", "Provider", "Vendor/Ollama", "Area/AI & Machine Learning", "Type/Library"]
+keywords = ["Agent", "Ollama", "Model", "Provider", "Vendor/Ollama", "Area/AI & Machine Learning", "Type/Connector"]
 license = ["Apache-2.0"]
 icon="icon.png"
 name = "ai.ollama"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.ollama"
-version = "1.2.2"
+version = "1.2.3"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.ollama-native"
-version = "1.2.2"
-path = "../native/build/libs/ai.ollama-native-1.2.2.jar"
+version = "1.2.3"
+path = "../native/build/libs/ai.ollama-native-1.2.3-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Ballerina"]
 distribution = "2201.12.0"
-keywords = ["Agent", "Ollama", "Model", "Provider", "Vendor/Ollama", "Area/AI & Machine Learning", "Type/Connector"]
+keywords = ["Agent", "Ollama", "Model", "Provider", "Vendor/Ollama", "Area/AI & Machine Learning", "Type/Library"]
 license = ["Apache-2.0"]
 icon="icon.png"
 name = "ai.ollama"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-ollama-compiler-plugin"
 class = "io.ballerina.lib.ai.ollama.AiOllamaCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.ollama-compiler-plugin-1.2.2.jar"
+path = "../compiler-plugin/build/libs/ai.ollama-compiler-plugin-1.2.3-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -116,7 +116,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -149,7 +149,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.ollama"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -68,9 +68,6 @@ version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "constraint", moduleName = "constraint"}
-]
 
 [[package]]
 org = "ballerina"
@@ -400,7 +397,6 @@ name = "ai.ollama"
 version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
-	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -267,8 +267,16 @@ isolated function generateLlmResponse(http:Client llmClient, string modelType,
             span.close(err);
             return err;
         }
-        responseStr = responseSchema.isOriginallyJsonObject ? content :
-            {[RESULT]: content}.toJsonString();
+        if responseSchema.isOriginallyJsonObject {
+            responseStr = content;
+        } else {
+            // Parse content as JSON so the wrapped value preserves its
+            // type (array, number, boolean, ...). Fall back to the raw
+            // string for plain string responses.
+            json|error parsed = content.fromJsonString();
+            json wrapped = parsed is json ? parsed : content;
+            responseStr = {[RESULT]: wrapped}.toJsonString();
+        }
     }
 
     anydata|error res = parseResponseAsType(responseStr, expectedResponseTypedesc,

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -214,7 +214,8 @@ isolated function generateLlmResponse(http:Client llmClient, string modelType,
     // responding with plain text.
     map<json> systemMessage = {
         role: ai:SYSTEM,
-        "content": string `You must always call the ${GET_RESULTS_TOOL} tool to submit your response. Never reply with plain text.`
+        "content": string `You must always call the ${GET_RESULTS_TOOL
+            } tool to submit your response. Never reply with plain text.`
     };
     map<json> userMessage = {role: ai:USER, "content": chatContent.text};
     if chatContent.images.length() > 0 {

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -85,16 +85,21 @@ isolated function getGetResultsTool(map<json> parameters) returns map<json>[] =>
         'function: {
             name: GET_RESULTS_TOOL,
             parameters: parameters,
-            description: string `Required Tool to call with the response from a large language model (LLM) for a user prompt. 
-                            This tool is mandatory for the LLM to return a response.`
+            description: "Submit the final answer. Call this tool with your response in the result field."
         }
     }
 ];
 
-isolated function generateChatCreationContent(ai:Prompt prompt) returns string|ai:Error {
+type ChatContent record {|
+    string text;
+    string[] images;
+|};
+
+isolated function generateChatCreationContent(ai:Prompt prompt) returns ChatContent|ai:Error {
     string[] & readonly strings = prompt.strings;
     anydata[] insertions = prompt.insertions;
     string promptStr = "";
+    string[] images = [];
 
     if strings.length() > 0 {
         promptStr += strings[0];
@@ -108,7 +113,8 @@ isolated function generateChatCreationContent(ai:Prompt prompt) returns string|a
             if insertion is ai:TextDocument {
                 promptStr += insertion.content + " ";
             } else if insertion is ai:ImageDocument {
-                promptStr += check addImageContentPart(insertion);
+                images.push(check getImageBase64(insertion));
+                promptStr += "[img]";
             } else {
                 return error ai:Error("Only Text and Image Documents are currently supported.");
             }
@@ -117,7 +123,8 @@ isolated function generateChatCreationContent(ai:Prompt prompt) returns string|a
                 if doc is ai:TextDocument {
                     promptStr += doc.content + " ";
                 } else if doc is ai:ImageDocument {
-                    promptStr += check addImageContentPart(doc);
+                    images.push(check getImageBase64(doc));
+                    promptStr += "[img]";
                 } else {
                     return error ai:Error("Only Text and Image Documents are currently supported.");
                 }
@@ -129,24 +136,52 @@ isolated function generateChatCreationContent(ai:Prompt prompt) returns string|a
     }
 
     promptStr += addToolDirective();
-    return promptStr.trim();
+    return {text: promptStr.trim(), images};
 }
 
-isolated function addImageContentPart(ai:ImageDocument doc) returns string|ai:Error {
+isolated function getImageBase64(ai:ImageDocument doc) returns string|ai:Error {
     ai:Url|byte[] content = doc.content;
     if content is ai:Url {
         ai:Url|constraint:Error validationRes = constraint:validate(content);
         if validationRes is error {
             return error(validationRes.message(), validationRes.cause());
         }
-        return string ` ${content} `;
+        return content;
     }
 
-    return string ` ${content.toBase64()} `;
+    return content.toBase64();
 }
 
 isolated function addToolDirective() returns string {
-    return "\nYou must call the `getResults` tool to obtain the correct answer.";
+    return "\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+}
+
+// Extracts content from markdown code fences (```json ... ``` or ``` ... ```).
+// If multiple code blocks exist, the last one is used (models often put the actual 
+// result there). If no code fences are found, returns the original content.
+isolated function stripCodeFences(string content) returns string {
+    int? lastFenceStart = content.lastIndexOf("```");
+    if lastFenceStart is () {
+        return content;
+    }
+    // Find the second-to-last ``` which is the opening fence of the last block
+    string beforeLastFence = content.substring(0, lastFenceStart);
+    int? openFenceStart = beforeLastFence.lastIndexOf("```");
+    if openFenceStart is () {
+        return content;
+    }
+    string fencedBlock = content.substring(openFenceStart);
+    // Remove opening fence line (``` or ```json, etc.)
+    int? firstNewline = fencedBlock.indexOf("\n");
+    if firstNewline is () {
+        return content;
+    }
+    string inner = fencedBlock.substring(firstNewline + 1);
+    // Remove closing fence
+    if inner.endsWith("```") {
+        inner = inner.substring(0, inner.length() - 3);
+    }
+    return inner.trim();
 }
 
 isolated function handleParseResponseError(error chatResponseError) returns error {
@@ -163,10 +198,10 @@ isolated function generateLlmResponse(http:Client llmClient, string modelType,
     observe:GenerateContentSpan span = observe:createGenerateContentSpan(modelType);
     span.addProvider("ollama");
 
-    string content;
+    ChatContent chatContent;
     ResponseSchema responseSchema;
     do {
-        content = check generateChatCreationContent(prompt);
+        chatContent = check generateChatCreationContent(prompt);
         responseSchema = check getExpectedResponseSchema(expectedResponseTypedesc);
     } on fail ai:Error err {
         span.close(err);
@@ -174,7 +209,18 @@ isolated function generateLlmResponse(http:Client llmClient, string modelType,
     }
 
     map<json>[] tools = getGetResultsTool(responseSchema.schema);
-    map<json>[] messages = [{role: ai:USER, "content": content}];
+    // Ollama does not support `tool_choice` to force tool calls, unlike some other providers.
+    // A system message is used to nudge local models into calling the tool instead of
+    // responding with plain text.
+    map<json> systemMessage = {
+        role: ai:SYSTEM,
+        "content": string `You must always call the ${GET_RESULTS_TOOL} tool to submit your response. Never reply with plain text.`
+    };
+    map<json> userMessage = {role: ai:USER, "content": chatContent.text};
+    if chatContent.images.length() > 0 {
+        userMessage["images"] = chatContent.images;
+    }
+    map<json>[] messages = [systemMessage, userMessage];
     map<json> request = {
         messages,
         tools,
@@ -205,15 +251,26 @@ isolated function generateLlmResponse(http:Client llmClient, string modelType,
     }
 
     OllamaToolCall[]? toolCalls = response.message?.tool_calls;
-    if toolCalls is () || toolCalls.length() == 0 {
-        ai:Error err = error(NO_RELEVANT_RESPONSE_FROM_THE_LLM);
-        span.close(err);
-        return err;
+    string responseStr;
+    if toolCalls is OllamaToolCall[] && toolCalls.length() > 0 {
+        OllamaToolCall tool = toolCalls[0];
+        map<json> arguments = tool.'function.arguments;
+        responseStr = arguments.toJsonString();
+    } else {
+        // Fallback: when the model responds with text instead of a tool call,
+        // attempt to parse the content directly. This is common with smaller
+        // models that do not reliably use the tool-calling mechanism.
+        string content = stripCodeFences(response.message.content.trim());
+        if content == "" {
+            ai:Error err = error(NO_RELEVANT_RESPONSE_FROM_THE_LLM);
+            span.close(err);
+            return err;
+        }
+        responseStr = responseSchema.isOriginallyJsonObject ? content :
+            {[RESULT]: content}.toJsonString();
     }
 
-    OllamaToolCall tool = toolCalls[0];
-    map<json> arguments = tool.'function.arguments;
-    anydata|error res = parseResponseAsType(arguments.toJsonString(), expectedResponseTypedesc,
+    anydata|error res = parseResponseAsType(responseStr, expectedResponseTypedesc,
             responseSchema.isOriginallyJsonObject);
     if res is error {
         ai:Error err = error(string `Invalid value returned from the LLM Client, expected: '${

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -84,7 +84,7 @@ isolated function getGetResultsTool(map<json> parameters) returns map<json>[] =>
         'function: {
             name: GET_RESULTS_TOOL,
             parameters: parameters,
-            description: "Submit the final answer. Call this tool with your response in the result field."
+            description: "Tool to call to submit the final answer."
         }
     }
 ];

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -167,18 +167,14 @@ isolated function stripCodeFences(string content) returns string {
     if openFenceStart is () {
         return content;
     }
-    string fencedBlock = content.substring(openFenceStart);
+    // Limit to the closing fence so trailing prose is excluded.
+    string fencedBlock = content.substring(openFenceStart, lastFenceStart);
     // Remove opening fence line (``` or ```json, etc.)
     int? firstNewline = fencedBlock.indexOf("\n");
     if firstNewline is () {
         return content;
     }
-    string inner = fencedBlock.substring(firstNewline + 1);
-    // Remove closing fence
-    if inner.endsWith("```") {
-        inner = inner.substring(0, inner.length() - 3);
-    }
-    return inner.trim();
+    return fencedBlock.substring(firstNewline + 1).trim();
 }
 
 isolated function handleParseResponseError(error chatResponseError) returns error {

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -16,7 +16,6 @@
 
 import ballerina/ai;
 import ballerina/ai.observe;
-import ballerina/constraint;
 import ballerina/http;
 
 type ResponseSchema record {|
@@ -142,11 +141,9 @@ isolated function generateChatCreationContent(ai:Prompt prompt) returns ChatCont
 isolated function getImageBase64(ai:ImageDocument doc) returns string|ai:Error {
     ai:Url|byte[] content = doc.content;
     if content is ai:Url {
-        ai:Url|constraint:Error validationRes = constraint:validate(content);
-        if validationRes is error {
-            return error(validationRes.message(), validationRes.cause());
-        }
-        return content;
+        return error(
+            "Ollama does not support URL-based images. " +
+            "Please provide the image as a byte array.");
     }
 
     return content.toBase64();

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -25,11 +25,24 @@ service /llm on new http:Listener(8080) {
                 "num_ctx":2048, "repeat_last_n":64, "repeat_penalty":1.1d, "temperature":0.8d, "seed":11,
                 "num_predict":-1, "top_k":40, "top_p":0.9d, "min_p":0d});
         json[] messages = check payload.messages.ensureType();
-        json message = messages[0];
+        test:assertEquals(messages.length(), 2, "Expected system, user");
+        test:assertEquals(messages[0].role, "system");
 
+        json message = messages[1];
         string content = check message.content.ensureType();
         test:assertEquals(content, getExpectedPrompt(content));
         test:assertEquals(message.role, "user");
+
+        string[][] expectedImages = getExpectedImages(content);
+        if expectedImages.length() > 0 {
+            json[] images = check message.images.ensureType();
+            test:assertEquals(images.length(), expectedImages[0].length(),
+                "Unexpected number of images in the payload");
+            foreach int i in 0 ..< expectedImages[0].length() {
+                test:assertEquals(images[i], expectedImages[0][i]);
+            }
+        }
+
         json[] tools = check payload.tools.ensureType();
         if tools.length() == 0 {
             test:assertFail("No tools in the payload");
@@ -39,6 +52,15 @@ service /llm on new http:Listener(8080) {
         map<json> parameters = check (tool.'function?.parameters).ensureType();
 
         test:assertEquals(parameters, getExpectedParameterSchema(content), string `Test failed for prompt:- ${content}`);
+
+        // Simulate models that respond with content instead of tool calls
+        string? fallbackContent = getFallbackContent(content);
+        if fallbackContent is string {
+            return {
+                model: "llama2",
+                message: {content: fallbackContent, role: "assistant"}
+            };
+        }
         return getTestServiceResponse(content);
     }
 }

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -55,14 +55,6 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
         return expectedParameterSchemaStringForRateBlog9;
     }
 
-    if message.startsWith("Describe this image.") {
-        return expectedParameterSchemaStringForRateBlog9;
-    }
-
-    if message.startsWith("Describe these images.") {
-        return expectedParameterSchemaStringForRateBlog8;
-    }
-
     if message.startsWith("How do you rate this blog") {
         return expectedParameterSchemaStringForRateBlog7;
     }
@@ -248,14 +240,6 @@ isolated function getTheMockLLMResult(string message) returns map<json> {
         return {"result": "This is a sample image description."};
     }
 
-    if message.startsWith("Describe this image.") {
-        return {"result": "This is a sample image description."};
-    }
-
-    if message.startsWith("Describe these images.") {
-        return {"result": ["This is a sample image description.", "This is a sample image description."]};
-    }
-    
     if message.startsWith("Name a random world class cricketer in India") {
         return {"result": {"name": "Sanga"}};
     }
@@ -386,16 +370,6 @@ isolated function getExpectedPrompt(string message) returns string {
         "You must submit your response by calling the `getResults` tool.";
     }
 
-    if message.startsWith("Describe this image.") {
-        return "Describe this image.[img].\nDo not respond with text. " +
-        "You must submit your response by calling the `getResults` tool.";
-    }
-
-    if message.startsWith("Describe these images.") {
-        return "Describe these images.[img][img].\nDo not respond with text. " +
-        "You must submit your response by calling the `getResults` tool.";
-    }
-    
     if message.startsWith("Name 10 world class cricketers in India") {
         return "Name 10 world class cricketers in India\nDo not respond with text. " +
         "You must submit your response by calling the `getResults` tool.";
@@ -516,14 +490,6 @@ isolated function getFallbackContent(string message) returns string? {
 isolated function getExpectedImages(string message) returns string[][] {
     if message.startsWith("Describe the following image.") {
         return [[sampleStringData]];
-    }
-
-    if message.startsWith("Describe this image.") {
-        return [["https://example.com/sample-image.jpg"]];
-    }
-
-    if message.startsWith("Describe these images.") {
-        return [[sampleStringData, "https://example.com/sample-image.jpg"]];
     }
 
     return [];

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -79,6 +79,22 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
         return expectedParamterSchemaStringForCountry;
     }
 
+    if message.startsWith("What is the capital of France?") {
+        return expectedParamterSchemaStringForCountry;
+    }
+
+    if message.startsWith("Review this restaurant") {
+        return expectedParameterSchemaStringForRateBlog2;
+    }
+
+    if message.startsWith("Summarize and rate this article") {
+        return expectedParameterSchemaStringForRateBlog2;
+    }
+
+    if message.startsWith("Translate this to French") {
+        return expectedParamterSchemaStringForCountry;
+    }
+
     if message.startsWith("Who is a popular sportsperson") {
         return {
             "type": "object",
@@ -349,56 +365,98 @@ isolated function getExpectedPrompt(string message) returns string {
     }
 
     if message.startsWith("Describe the following image.") {
-        return string `Describe the following image. ${sampleStringData} .${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        return "Describe the following image.[img].\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Describe this image.") {
-        return "Describe this image. https://example.com/sample-image.jpg .\nYou must call the `getResults` tool to obtain the correct answer.";
+        return "Describe this image.[img].\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Describe these images.") {
-        return string `Describe these images. ${sampleStringData}  https://example.com/sample-image.jpg .${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        return "Describe these images.[img][img].\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
     
     if message.startsWith("Name 10 world class cricketers in India") {
-        return "Name 10 world class cricketers in India\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Name 10 world class cricketers in India\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name 10 world class cricketers as string") {
-        return "Name 10 world class cricketers as string\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Name 10 world class cricketers as string\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name 10 world class cricketers") {
-        return "Name 10 world class cricketers\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Name 10 world class cricketers\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name top 10 world class cricketers") {
-        return "Name top 10 world class cricketers\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Name top 10 world class cricketers\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name a random world class cricketer in India") {
-        return "Name a random world class cricketer in India\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Name a random world class cricketer in India\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name a random world class cricketer") {
-        return "Name a random world class cricketer\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Name a random world class cricketer\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Give me a random joke about cricketers") {
-        return "Give me a random joke about cricketers\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Give me a random joke about cricketers\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Give me a random joke") {
-        return "Give me a random joke\nYou must call the `getResults`" +
-        " tool to obtain the correct answer.";
+        return "Give me a random joke\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+    }
+
+    if message.startsWith("What is the capital of France?") {
+        return "What is the capital of France?\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+    }
+
+    if message.startsWith("Review this restaurant") {
+        return "Review this restaurant in detail\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+    }
+
+    if message.startsWith("Summarize and rate this article") {
+        return "Summarize and rate this article\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+    }
+
+    if message.startsWith("Translate this to French") {
+        return "Translate this to French\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
     }
 
     return "INVALID";
+}
+
+// Returns content for prompts that should simulate a content-only response (no tool call).
+// Returns nil for prompts that should use the normal tool-call path.
+isolated function getFallbackContent(string message) returns string? {
+    if message.startsWith("What is the capital of France?") {
+        return "Paris";
+    }
+    if message.startsWith("Review this restaurant") {
+        return "{\"rating\": 8, \"comment\": \"Great blog!\"}";
+    }
+    if message.startsWith("Summarize and rate this article") {
+        return "Here is the result:\n```json\n{\"rating\": 8, \"comment\": \"Great blog!\"}\n```";
+    }
+    if message.startsWith("Translate this to French") {
+        return "";
+    }
+    return ();
+}
+
+isolated function getExpectedImages(string message) returns string[][] {
+    if message.startsWith("Describe the following image.") {
+        return [[sampleStringData]];
+    }
+
+    if message.startsWith("Describe this image.") {
+        return [["https://example.com/sample-image.jpg"]];
+    }
+
+    if message.startsWith("Describe these images.") {
+        return [[sampleStringData, "https://example.com/sample-image.jpg"]];
+    }
+
+    return [];
 }

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -365,63 +365,78 @@ isolated function getExpectedPrompt(string message) returns string {
     }
 
     if message.startsWith("Describe the following image.") {
-        return "Describe the following image.[img].\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Describe the following image.[img].\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Describe this image.") {
-        return "Describe this image.[img].\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Describe this image.[img].\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Describe these images.") {
-        return "Describe these images.[img][img].\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Describe these images.[img][img].\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
     
     if message.startsWith("Name 10 world class cricketers in India") {
-        return "Name 10 world class cricketers in India\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Name 10 world class cricketers in India\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name 10 world class cricketers as string") {
-        return "Name 10 world class cricketers as string\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Name 10 world class cricketers as string\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name 10 world class cricketers") {
-        return "Name 10 world class cricketers\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Name 10 world class cricketers\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name top 10 world class cricketers") {
-        return "Name top 10 world class cricketers\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Name top 10 world class cricketers\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name a random world class cricketer in India") {
-        return "Name a random world class cricketer in India\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Name a random world class cricketer in India\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Name a random world class cricketer") {
-        return "Name a random world class cricketer\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Name a random world class cricketer\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Give me a random joke about cricketers") {
-        return "Give me a random joke about cricketers\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Give me a random joke about cricketers\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Give me a random joke") {
-        return "Give me a random joke\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Give me a random joke\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("What is the capital of France?") {
-        return "What is the capital of France?\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "What is the capital of France?\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Review this restaurant") {
-        return "Review this restaurant in detail\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Review this restaurant in detail\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Summarize and rate this article") {
-        return "Summarize and rate this article\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Summarize and rate this article\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     if message.startsWith("Translate this to French") {
-        return "Translate this to French\nDo not respond with text. You must submit your response by calling the `getResults` tool.";
+        return "Translate this to French\nDo not respond with text. " +
+        "You must submit your response by calling the `getResults` tool.";
     }
 
     return "INVALID";

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -91,6 +91,23 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
         return expectedParameterSchemaStringForRateBlog2;
     }
 
+    if message.startsWith("List three numbers") {
+        return expectedParameterSchemaStringForRateBlog6;
+    }
+
+    if message.startsWith("How many continents") {
+        return expectedParameterSchemaStringForRateBlog;
+    }
+
+    if message.startsWith("What is the value of pi") {
+        return {"type": "object", "properties": {
+            "result": {"type": "number"}}};
+    }
+
+    if message.startsWith("Is the earth round") {
+        return expectedParameterSchemaStringForRateBlog3;
+    }
+
     if message.startsWith("Translate this to French") {
         return expectedParamterSchemaStringForCountry;
     }
@@ -434,6 +451,30 @@ isolated function getExpectedPrompt(string message) returns string {
         "You must submit your response by calling the `getResults` tool.";
     }
 
+    if message.startsWith("List three numbers") {
+        return "List three numbers between 1 and 5\nDo not respond" +
+        " with text. You must submit your response by calling" +
+        " the `getResults` tool.";
+    }
+
+    if message.startsWith("How many continents") {
+        return "How many continents are there\nDo not respond" +
+        " with text. You must submit your response by calling" +
+        " the `getResults` tool.";
+    }
+
+    if message.startsWith("What is the value of pi") {
+        return "What is the value of pi to 2 decimals\nDo not" +
+        " respond with text. You must submit your response by" +
+        " calling the `getResults` tool.";
+    }
+
+    if message.startsWith("Is the earth round") {
+        return "Is the earth round\nDo not respond with text. " +
+        "You must submit your response by calling the " +
+        "`getResults` tool.";
+    }
+
     if message.startsWith("Translate this to French") {
         return "Translate this to French\nDo not respond with text. " +
         "You must submit your response by calling the `getResults` tool.";
@@ -453,6 +494,18 @@ isolated function getFallbackContent(string message) returns string? {
     }
     if message.startsWith("Summarize and rate this article") {
         return "Here is the result:\n```json\n{\"rating\": 8, \"comment\": \"Great blog!\"}\n```";
+    }
+    if message.startsWith("List three numbers") {
+        return "[1, 3, 5]";
+    }
+    if message.startsWith("How many continents") {
+        return "7";
+    }
+    if message.startsWith("What is the value of pi") {
+        return "3.14";
+    }
+    if message.startsWith("Is the earth round") {
+        return "true";
     }
     if message.startsWith("Translate this to French") {
         return "";

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -83,6 +83,10 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
         return expectedParameterSchemaStringForRateBlog2;
     }
 
+    if message.startsWith("Summarize and rate this blog post") {
+        return expectedParameterSchemaStringForRateBlog2;
+    }
+
     if message.startsWith("List three numbers") {
         return expectedParameterSchemaStringForRateBlog6;
     }
@@ -425,6 +429,12 @@ isolated function getExpectedPrompt(string message) returns string {
         "You must submit your response by calling the `getResults` tool.";
     }
 
+    if message.startsWith("Summarize and rate this blog post") {
+        return "Summarize and rate this blog post\nDo not respond" +
+        " with text. You must submit your response by calling" +
+        " the `getResults` tool.";
+    }
+
     if message.startsWith("List three numbers") {
         return "List three numbers between 1 and 5\nDo not respond" +
         " with text. You must submit your response by calling" +
@@ -467,7 +477,13 @@ isolated function getFallbackContent(string message) returns string? {
         return "{\"rating\": 8, \"comment\": \"Great blog!\"}";
     }
     if message.startsWith("Summarize and rate this article") {
-        return "Here is the result:\n```json\n{\"rating\": 8, \"comment\": \"Great blog!\"}\n```";
+        return "Here is the result:\n```json\n" +
+        "{\"rating\": 8, \"comment\": \"Great blog!\"}\n```";
+    }
+    if message.startsWith("Summarize and rate this blog post") {
+        return "Here is the result:\n```json\n" +
+        "{\"rating\": 8, \"comment\": \"Great blog!\"}\n" +
+        "```\nHope that helps!";
     }
     if message.startsWith("List three numbers") {
         return "[1, 3, 5]";

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -55,41 +55,53 @@ const reviewRecord = {
 
 final string expectedPromptStringForRateBlog = string `Rate this blog out of 10.
         Title: ${blog1.title}
-        Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+        Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"
+        }getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog2 = string `Please rate this blog out of 10.
         Title: ${blog2.title}
-        Content: ${blog2.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+        Content: ${blog2.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"
+        }getResults${"`"} tool.`;
 
-const expectedPromptStringForRateBlog3 = string `What is 1 + 1?${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+const expectedPromptStringForRateBlog3 = string `What is 1 + 1?${"\n"
+        }Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
-const expectedPromptStringForRateBlog4 = string `Tell me name and the age of the top 10 world class cricketers${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+const expectedPromptStringForRateBlog4 = string `Tell me name and the age of the top 10 world class cricketers${"\n"
+        }Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog5 =
-        string `How would you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+        string `How would you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"
+        }Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog6 =
-        string `How would you rate this blog out of 10. Title: ${blog1.title} Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+        string `How would you rate this blog out of 10. Title: ${blog1.title} Content: ${blog1.content}${"\n"
+            }Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog7 =
         string `Please rate this blogs out of 10.
-        [{Title: ${blog1.title}, Content: ${blog1.content}}, {Title: ${blog2.title}, Content: ${blog2.content}}]${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+        [{Title: ${blog1.title}, Content: ${blog1.content}}, {Title: ${blog2.title}, Content: ${blog2.content}}]${"\n"
+        }Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog8 =
-    string `How would you rate this text blog out of 10, Title: ${blog1.title} Content: ${blog1.content} .${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+    string `How would you rate this text blog out of 10, Title: ${blog1.title} Content: ${blog1.content} .${"\n"
+    }Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog9 = string
-    `How would you rate this text blogs out of 10. Title: ${blog1.title} Content: ${blog1.content} Title: ${blog1.title} Content: ${blog1.content} . Thank you!${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+    `How would you rate this text blogs out of 10. Title: ${blog1.title} Content: ${blog1.content} Title: ${blog1.title
+    } Content: ${blog1.content} . Thank you!${"\n"}Do not respond with text. You must submit your response by calling the ${"`"
+    }getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog10 = string `Evaluate this blogs out of 10.
         Title: ${blog1.title}
         Content: ${blog1.content}
 
         Title: ${blog1.title}
-        Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+        Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"
+        }getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog11 =
-        string `How do you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+        string `How do you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"
+        }Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 const expectedPromptStringForBalProgram = string `What's the output of the Ballerina code below?
 
@@ -103,7 +115,8 @@ const expectedPromptStringForBalProgram = string `What's the output of the Balle
     }
     ${"```"}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
-const expectedPromptStringForCountry = string `Which country is known as the pearl of the Indian Ocean?${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
+const expectedPromptStringForCountry = string `Which country is known as the pearl of the Indian Ocean?${"\n"
+}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 const expectedParameterSchemaStringForRateBlog =
     {"type": "object", "properties": {"result": {"type": "integer"}}};

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -55,41 +55,41 @@ const reviewRecord = {
 
 final string expectedPromptStringForRateBlog = string `Rate this blog out of 10.
         Title: ${blog1.title}
-        Content: ${blog1.content}${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog2 = string `Please rate this blog out of 10.
         Title: ${blog2.title}
-        Content: ${blog2.content}${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        Content: ${blog2.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
-const expectedPromptStringForRateBlog3 = string `What is 1 + 1?${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+const expectedPromptStringForRateBlog3 = string `What is 1 + 1?${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
-const expectedPromptStringForRateBlog4 = string `Tell me name and the age of the top 10 world class cricketers${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+const expectedPromptStringForRateBlog4 = string `Tell me name and the age of the top 10 world class cricketers${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog5 =
-        string `How would you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        string `How would you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog6 =
-        string `How would you rate this blog out of 10. Title: ${blog1.title} Content: ${blog1.content}${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        string `How would you rate this blog out of 10. Title: ${blog1.title} Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog7 =
         string `Please rate this blogs out of 10.
-        [{Title: ${blog1.title}, Content: ${blog1.content}}, {Title: ${blog2.title}, Content: ${blog2.content}}]${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        [{Title: ${blog1.title}, Content: ${blog1.content}}, {Title: ${blog2.title}, Content: ${blog2.content}}]${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog8 =
-    string `How would you rate this text blog out of 10, Title: ${blog1.title} Content: ${blog1.content} .${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+    string `How would you rate this text blog out of 10, Title: ${blog1.title} Content: ${blog1.content} .${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog9 = string
-    `How would you rate this text blogs out of 10. Title: ${blog1.title} Content: ${blog1.content} Title: ${blog1.title} Content: ${blog1.content} . Thank you!${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+    `How would you rate this text blogs out of 10. Title: ${blog1.title} Content: ${blog1.content} Title: ${blog1.title} Content: ${blog1.content} . Thank you!${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog10 = string `Evaluate this blogs out of 10.
         Title: ${blog1.title}
         Content: ${blog1.content}
 
         Title: ${blog1.title}
-        Content: ${blog1.content}${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        Content: ${blog1.content}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 final string expectedPromptStringForRateBlog11 =
-        string `How do you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+        string `How do you rate this blog content out of 10. Title: ${blog1.title} Content: ${blog1.content} .${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 const expectedPromptStringForBalProgram = string `What's the output of the Ballerina code below?
 
@@ -101,9 +101,9 @@ const expectedPromptStringForBalProgram = string `What's the output of the Balle
         int y = 20;
         io:println(x + y);
     }
-    ${"```"}${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+    ${"```"}${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
-const expectedPromptStringForCountry = string `Which country is known as the pearl of the Indian Ocean?${"\n"}You must call the ${"`"}getResults${"`"} tool to obtain the correct answer.`;
+const expectedPromptStringForCountry = string `Which country is known as the pearl of the Indian Ocean?${"\n"}Do not respond with text. You must submit your response by calling the ${"`"}getResults${"`"} tool.`;
 
 const expectedParameterSchemaStringForRateBlog =
     {"type": "object", "properties": {"result": {"type": "integer"}}};

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -280,3 +280,28 @@ function testGenerateMethodWithArrayUnionRecord2() returns ai:Error? {
    Cricketers7[]|Cricketers8|error result = ollamaProvider->generate(`Name a random world class cricketer`);
     test:assertTrue(result is Cricketers8);
 }
+
+@test:Config
+function testFallbackPlainTextContent() returns ai:Error? {
+    string result = check ollamaProvider->generate(`What is the capital of France?`);
+    test:assertEquals(result, "Paris");
+}
+
+@test:Config
+function testFallbackJsonContent() returns error? {
+    Review result = check ollamaProvider->generate(`Review this restaurant in detail`);
+    test:assertEquals(result, {rating: 8, comment: "Great blog!"});
+}
+
+@test:Config
+function testFallbackCodeFenceContent() returns error? {
+    Review result = check ollamaProvider->generate(`Summarize and rate this article`);
+    test:assertEquals(result, {rating: 8, comment: "Great blog!"});
+}
+
+@test:Config
+function testFallbackEmptyContent() returns ai:Error? {
+    string|error result = ollamaProvider->generate(`Translate this to French`);
+    test:assertTrue(result is error);
+    test:assertEquals((<error>result).message(), "No relevant response from the LLM");
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -133,24 +133,17 @@ function testGenerateMethodWithImageDocument() returns ai:Error? {
         content: "https://example.com/sample-image.jpg"
     };
 
-    ai:ImageDocument img3 = {
-        content: "<invalid-url>"
-    };
-
-    string|error description = ollamaProvider->generate(`Describe the following image.${img}.`);
+    string|error description =
+        ollamaProvider->generate(`Describe the following image.${img}.`);
     test:assertEquals(description, "This is a sample image description.");
 
+    // Ollama does not support URL-based images
     description = ollamaProvider->generate(`Describe this image.${img2}.`);
-    test:assertEquals(description, "This is a sample image description.");
-
-    string[]|error descriptions = ollamaProvider->generate(`Describe these images.${<ai:ImageDocument[]>[img, img2]}.`);
-    test:assertEquals(descriptions, ["This is a sample image description.", "This is a sample image description."]);
-
-    description = ollamaProvider->generate(`Describe this image. ${img3}.`);
-    if description is string {
-        test:assertFail();
+    if description !is error {
+        test:assertFail("Expected error for URL-based image");
     }
-    test:assertEquals(description.message(), "Must be a valid URL.");
+    test:assertTrue(description.message().includes(
+        "Ollama does not support URL-based images"));
 }
 
 @test:Config
@@ -169,8 +162,10 @@ function testGenerateMethodWithInvalidDocument() returns ai:Error? {
 @test:Config
 function testGenerateMethodWithInvalidBasicType() returns ai:Error? {
     boolean|error rating = ollamaProvider->generate(`What is ${1} + ${1}?`);
-    test:assertTrue(rating is error);
-    test:assertTrue((<error>rating).message().includes(ERROR_MESSAGE));
+    if rating !is error {
+        test:assertFail("Expected error for unsupported type");
+    }
+    test:assertTrue(rating.message().includes(ERROR_MESSAGE));
 }
 
 type ProductName record {|
@@ -181,10 +176,13 @@ type ProductName record {|
 function testGenerateMethodWithInvalidRecordType() returns ai:Error? {
     ProductName[]|map<string>|error rating = trap ollamaProvider->generate(
                 `Tell me name and the age of the top 10 world class cricketers`);
-    string msg = (<error>rating).message();
-    test:assertTrue(rating is error);
-    test:assertTrue(msg.includes(RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE),
-        string `expected error message to contain: ${RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE}, but found ${msg}`);
+    if rating !is error {
+        test:assertFail("Expected error for unsupported type");
+    }
+    test:assertTrue(rating.message().includes(RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE),
+        string `expected error message to contain: ${
+            RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE
+        }, but found ${rating.message()}`);
 }
 
 type ProductNameArray ProductName[];
@@ -193,8 +191,10 @@ type ProductNameArray ProductName[];
 function testGenerateMethodWithInvalidRecordArrayType2() returns ai:Error? {
     ProductNameArray|error rating = ollamaProvider->generate(
                 `Tell me name and the age of the top 10 world class cricketers`);
-    test:assertTrue(rating is error);
-    test:assertTrue((<error>rating).message().includes(ERROR_MESSAGE));
+    if rating !is error {
+        test:assertFail("Expected error for unsupported type");
+    }
+    test:assertTrue(rating.message().includes(ERROR_MESSAGE));
 }
 
 type Cricketers record {|
@@ -330,6 +330,8 @@ function testFallbackBooleanType() returns ai:Error? {
 @test:Config
 function testFallbackEmptyContent() returns ai:Error? {
     string|error result = ollamaProvider->generate(`Translate this to French`);
-    test:assertTrue(result is error);
-    test:assertEquals((<error>result).message(), "No relevant response from the LLM");
+    if result !is error {
+        test:assertFail("Expected error for empty content");
+    }
+    test:assertEquals(result.message(), "No relevant response from the LLM");
 }

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -133,8 +133,7 @@ function testGenerateMethodWithImageDocument() returns ai:Error? {
         content: "https://example.com/sample-image.jpg"
     };
 
-    string|error description =
-        ollamaProvider->generate(`Describe the following image.${img}.`);
+    string|error description = ollamaProvider->generate(`Describe the following image.${img}.`);
     test:assertEquals(description, "This is a sample image description.");
 
     // Ollama does not support URL-based images
@@ -300,6 +299,13 @@ function testFallbackCodeFenceContent() returns error? {
 }
 
 @test:Config
+function testFallbackCodeFenceWithTrailingText() returns error? {
+    Review result = check ollamaProvider->generate(
+        `Summarize and rate this blog post`);
+    test:assertEquals(result, {rating: 8, comment: "Great blog!"});
+}
+
+@test:Config
 function testFallbackIntArrayType() returns ai:Error? {
     int[] result = check ollamaProvider->generate(
         `List three numbers between 1 and 5`);
@@ -322,8 +328,7 @@ function testFallbackFloatType() returns ai:Error? {
 
 @test:Config
 function testFallbackBooleanType() returns ai:Error? {
-    boolean result = check ollamaProvider->generate(
-        `Is the earth round`);
+    boolean result = check ollamaProvider->generate(`Is the earth round`);
     test:assertEquals(result, true);
 }
 

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -300,6 +300,34 @@ function testFallbackCodeFenceContent() returns error? {
 }
 
 @test:Config
+function testFallbackIntArrayType() returns ai:Error? {
+    int[] result = check ollamaProvider->generate(
+        `List three numbers between 1 and 5`);
+    test:assertEquals(result, [1, 3, 5]);
+}
+
+@test:Config
+function testFallbackIntType() returns ai:Error? {
+    int result = check ollamaProvider->generate(
+        `How many continents are there`);
+    test:assertEquals(result, 7);
+}
+
+@test:Config
+function testFallbackFloatType() returns ai:Error? {
+    float result = check ollamaProvider->generate(
+        `What is the value of pi to 2 decimals`);
+    test:assertEquals(result, 3.14);
+}
+
+@test:Config
+function testFallbackBooleanType() returns ai:Error? {
+    boolean result = check ollamaProvider->generate(
+        `Is the earth round`);
+    test:assertEquals(result, true);
+}
+
+@test:Config
 function testFallbackEmptyContent() returns ai:Error? {
     string|error result = ollamaProvider->generate(`Translate this to French`);
     test:assertTrue(result is error);

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Ballerina"]
 distribution = "2201.12.0"
-keywords = ["Agent", "Ollama", "Model", "Provider", "Vendor/Ollama", "Area/AI & Machine Learning", "Type/Connector"]
+keywords = ["Agent", "Ollama", "Model", "Provider", "Vendor/Ollama", "Area/AI & Machine Learning", "Type/Library"]
 license = ["Apache-2.0"]
 icon="icon.png"
 name = "ai.ollama"


### PR DESCRIPTION
## Purpose

- Reword tool description and prompt directive to instruct the model to submit its response via the tool, preventing models from explaining the tool instead of calling it  
- Pass images via the Ollama `images` field with `[img]` placeholders instead of inlining base64 data in the prompt text
- Add a system message to reinforce tool-call usage since Ollama does not support `tool_choice`                                                                                                                                                                                         
- Fall back to parsing the content field when the model responds with text instead of a tool call, including stripping markdown code fences 
- Disallow URL-based image input since Ollama doesn't support that - eventually, we could handle it in the model provider side
 
Fixes: https://github.com/wso2/product-integrator/issues/760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request improves the Ollama model provider integration by refactoring image handling, tightening model guidance for tool usage, and adding resilient fallback parsing and tests to ensure reliable generate() behavior.

Key changes
- Model guidance: Rewords tool descriptions and prompt directives and adds a system message so models submit results via the getResults tool instead of replying in plain text.
- Image handling: Stops inlining base64 image data in prompt text; prompts now include “[img]” placeholders and images are sent via Ollama’s images field as base64 binaries. URL-based image inputs are disallowed for Ollama.
- Fallback parsing: Adds robust fallback logic to parse plain-text model responses (including stripping markdown code fences and extracting JSON or primitive values) when the model does not perform a tool call.
- Tests and validation: Updates test utilities and service tests to validate the new system+user message structure, images array payload, and fallback behaviors; expands mock handlers and adds tests covering plain-text/JSON/code-fence fallbacks and typed deserialization.
- Dependency and metadata updates: Bumps package version 1.2.2 → 1.2.3, updates ai.ollama native/compiler-plugin artifacts, adjusts several Ballerina dependencies, removes an unused constraint dependency, and updates package keywords.

Outcome
- Enables attaching image documents in prompts for the Ollama provider via a dedicated images field, enforces tool-based response submission, and improves generate() reliability and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->